### PR TITLE
build: merge coverall results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             go test -v -cover -race -timeout=60s -coverprofile=./coverage.out $(go list ./...)
             GOFLAGS=-mod= goveralls -coverprofile=./coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       # goveralls will ignore vendor dir and download stuff, so we cache its results here
-      - save_cache:go
+      - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"


### PR DESCRIPTION
repo_token is hard coded in config.yml. That should moved to circle-ci env variable, and the token should be regenerated.