### PR TITLE
chore: use partial update on Logstash ES output

### DIFF
--- a/deployments/docker/conf/logstash/conf.d/80_siem.conf
+++ b/deployments/docker/conf/logstash/conf.d/80_siem.conf
@@ -76,13 +76,19 @@ filter {
       	  "[@metadata][target_index]" => "siem_alarms-%{+YYYY.MM.dd}"
         }
       }
+    } else {
+      # existing document, so we:
+      # - remove tag and status to avoid overwriting changes made by users 
+      mutate {
+        remove_field => [ "status", "tag" ]
+      }
     }
     # elasticsearch filter plugin only search within _source, so the following extra perm_index field is necessary
     mutate {
       add_field => {
       	"perm_index" => "%{[@metadata][target_index]}"
       }
-    } 
+    }
     prune {
       whitelist_names => [ "timestamp", "@metadata", "title", "status", "kingdom", "category",
         "updated_time", "risk", "risk_class", "tag$", "src_ips", "dst_ips", "intel_hits", "vulnerabilities",
@@ -101,6 +107,8 @@ output {
       template_overwrite => true
     }
   }
+  # This one uses update action and doc_as_upsert to allow partial updates, thereby
+  # retaining the existing tag and status potentially set by users
   if [@metadata][siem_data_type] == "alarms" {
     elasticsearch {
       hosts => "elasticsearch:9200"
@@ -109,6 +117,9 @@ output {
       template => "/etc/logstash/index-template.d/siem_alarms-template.json"
       template_name => "siem_alarms"
       template_overwrite => true
+      action => "update"
+      doc_as_upsert => true
+      retry_on_conflict => 5
     }
   }
 }


### PR DESCRIPTION
This excludes tag and status fields during document updates in order to retain
any user modification to them