### PR TITLE
feat: new directive option: all_rules_always_active

### DIFF
--- a/internal/pkg/dsiem/siem/backlogmgr.go
+++ b/internal/pkg/dsiem/siem/backlogmgr.go
@@ -290,11 +290,24 @@ func createNewBackLog(d Directive, e event.NormalizedEvent) (bp *backLog, err er
 }
 
 func initBackLogRules(d *Directive, e event.NormalizedEvent) {
+
 	for i := range d.Rules {
-		// the first rule cannot use reference to other
 		if i == 0 {
+			// if flag is active, replace ANY and HOME_NET on the first rule with specific addresses from event
+			if d.AllRulesAlwaysActive {
+				ref := d.Rules[i].From
+				if ref == "ANY" || ref == "HOME_NET" || ref == "!HOME_NET" {
+					d.Rules[i].From = e.SrcIP
+				}
+				ref = d.Rules[i].To
+				if ref == "ANY" || ref == "HOME_NET" || ref == "!HOME_NET" {
+					d.Rules[i].To = e.DstIP
+				}
+			}
+			// the first rule cannot use reference to other
 			continue
 		}
+
 		// for the rest, refer to the referenced stage if its not ANY or HOME_NET or !HOME_NET
 		// if the reference is ANY || HOME_NET || !HOME_NET then refer to event if its in the format of
 		// :ref

--- a/internal/pkg/dsiem/siem/directive.go
+++ b/internal/pkg/dsiem/siem/directive.go
@@ -43,14 +43,15 @@ const (
 
 // Directive represents a SIEM use case that has several correlation rules
 type Directive struct {
-	ID          int                   `json:"id"`
-	Name        string                `json:"name"`
-	Priority    int                   `json:"priority"`
-	Disabled    bool                  `json:"disabled"`
-	Kingdom     string                `json:"kingdom"`
-	Category    string                `json:"category"`
-	Rules       []rule.DirectiveRule  `json:"rules"`
-	StickyDiffs []rule.StickyDiffData `json:"-"`
+	ID                   int                   `json:"id"`
+	Name                 string                `json:"name"`
+	Priority             int                   `json:"priority"`
+	Disabled             bool                  `json:"disabled"`
+	AllRulesAlwaysActive bool                  `json:"all_rules_always_active"`
+	Kingdom              string                `json:"kingdom"`
+	Category             string                `json:"category"`
+	Rules                []rule.DirectiveRule  `json:"rules"`
+	StickyDiffs          []rule.StickyDiffData `json:"-"`
 }
 
 // Directives group directive together
@@ -307,6 +308,7 @@ func copyDirective(dst *Directive, src Directive, e event.NormalizedEvent) {
 	dst.Priority = src.Priority
 	dst.Kingdom = src.Kingdom
 	dst.Category = src.Category
+	dst.AllRulesAlwaysActive = src.AllRulesAlwaysActive
 
 	// replace SRC_IP and DST_IP with the asset name or IP address
 	title := src.Name

--- a/internal/pkg/dsiem/siem/fixtures/directive4/directives_dsiem-backend-0_testing1.json
+++ b/internal/pkg/dsiem/siem/fixtures/directive4/directives_dsiem-backend-0_testing1.json
@@ -1,18 +1,64 @@
 {
   "directives": [
     {
-      "name": "Correct Rule, Attack from SRC_IP to DST_IP",
+      "name": "Correct Rule with Always Active Option, Attack from SRC_IP to DST_IP",
       "kingdom": "Reconnaissance & Probing",
       "category": "Misc Activity",
+      "all_rules_always_active": true,
       "id": 5,
       "priority": 3,
-      "rules" : [
-        { "name": "ICMP Ping", "type": "PluginRule", "stage": 1, "plugin_id": 1001, "plugin_sid": [ 2100384 ], "occurrence": 1, 
-          "from": "HOME_NET", "to": "ANY", "port_from": "ANY", "port_to": "ANY", "protocol": "ICMP", "reliability": 1, "timeout": 0 },
-        { "name": "ICMP Ping", "type": "PluginRule", "stage": 2, "plugin_id": 1001, "plugin_sid": [ 2100384 ], "occurrence": 1,
-          "from": ":1", "to": ":1", "port_from": ":1", "port_to": "ANY", "protocol": "ICMP", "reliability": 6, "timeout": 3 },
-        { "name": "ICMP Ping", "type": "PluginRule", "stage": 3, "plugin_id": 1001, "plugin_sid": [ 2100384 ], "occurrence": 1,
-          "from": ":1", "to": ":1", "port_from": ":1", "port_to": "ANY", "protocol": "ICMP", "reliability": 6, "timeout": 3 }
+      "rules": [
+        {
+          "name": "ICMP Ping",
+          "type": "PluginRule",
+          "stage": 1,
+          "plugin_id": 1001,
+          "plugin_sid": [
+            2100384
+          ],
+          "occurrence": 1,
+          "from": "HOME_NET",
+          "to": "ANY",
+          "port_from": "ANY",
+          "port_to": "ANY",
+          "protocol": "ICMP",
+          "reliability": 1,
+          "timeout": 0
+        },
+        {
+          "name": "ICMP Ping",
+          "type": "PluginRule",
+          "stage": 2,
+          "plugin_id": 1001,
+          "plugin_sid": [
+            2100385
+          ],
+          "occurrence": 1,
+          "from": ":1",
+          "to": ":1",
+          "port_from": ":1",
+          "port_to": "ANY",
+          "protocol": "ICMP",
+          "reliability": 6,
+          "timeout": 3
+        },
+        {
+          "name": "ICMP Ping",
+          "type": "PluginRule",
+          "stage": 3,
+          "plugin_id": 1001,
+          "plugin_sid": [
+            2100385
+          ],
+          "occurrence": 1,
+          "from": ":1",
+          "to": ":1",
+          "port_from": ":1",
+          "port_to": "ANY",
+          "protocol": "ICMP",
+          "reliability": 6,
+          "timeout": 3
+        }
       ]
     }
   ]

--- a/scripts/dockerbuild-dev.sh
+++ b/scripts/dockerbuild-dev.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+builddir=./test/docker-dev
+s6file=s6-overlay-amd64.tar.gz
+mkdir -p $builddir
+
+([ ! -z "$SKIP_CMD" ] && echo not building cmd || ./scripts/gobuild-cmd.sh ./cmd/dsiem) && \
+([ ! -z "$SKIP_WEB" ] && echo not building web || ./scripts/ngbuild-web.sh) && \
+cp ./dsiem $builddir/ && \
+cp -r ./web/dist $builddir/ && \
+cp -r ./deployments/docker/build/s6files $builddir/ && \
+cp -r ./configs $builddir/ && \
+
+([ -e "$builddir/$s6file" ] && echo $s6file already exist || wget https://github.com/just-containers/s6-overlay/releases/download/v1.20.0.0/s6-overlay-amd64.tar.gz -O $builddir/$s6file) && \
+cd $builddir/ && \
+touch Dockerfile && \
+{
+cat << EOF > Dockerfile
+FROM alpine:edge
+# Install packages
+RUN apk -U upgrade && \ 
+    apk add bash ca-certificates wget unzip && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /dsiem/web /dsiem/logs
+COPY dsiem /dsiem/dsiem
+COPY configs /dsiem/configs
+COPY dist /dsiem/web/dist
+
+# configs-dist will be used to prepopulate /dsiem/configs if it's mounted off a new empty volume
+RUN cp -r /dsiem/configs /dsiem/configs-dist && rm -rf /dsiem/configs/*
+
+# s6-overlay
+COPY s6-overlay-amd64.tar.gz /tmp/
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
+
+ENV TERM xterm-256color
+# copy s6files and set default to expose all container env to the target app
+ADD s6files /etc/
+ENV S6_KEEP_ENV 1
+# fail container if init scripts failed
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 2
+
+VOLUME ["/dsiem/logs", "/dsiem/configs" ]
+EXPOSE 8080
+ENTRYPOINT [ "/init"]
+
+EOF
+} && docker build . -t defenxor/dsiem-devel

--- a/web/ui/src/app/views/base/detailalarm.component.ts
+++ b/web/ui/src/app/views/base/detailalarm.component.ts
@@ -113,7 +113,7 @@ export class DetailalarmComponent implements OnInit, OnDestroy {
         await Promise.all(e['_source']['rules'].map(async (r) => {
           // if (r['status'] === 'finished') {
           //  r['events_count'] = r['occurrence'];
-          //} else {
+          // } else {
             const response = await this.es.countEvents(this.es.esIndexAlarmEvent, alarmID, r['stage']);
             r['events_count'] = response.count;
           // }

--- a/web/ui/src/app/views/base/detailalarm.component.ts
+++ b/web/ui/src/app/views/base/detailalarm.component.ts
@@ -111,12 +111,12 @@ export class DetailalarmComponent implements OnInit, OnDestroy {
       tempAlarms = resp.hits.hits;
       await Promise.all(tempAlarms.map(async (e) => {
         await Promise.all(e['_source']['rules'].map(async (r) => {
-          if (r['status'] === 'finished') {
-            r['events_count'] = r['occurrence'];
-          } else {
+          // if (r['status'] === 'finished') {
+          //  r['events_count'] = r['occurrence'];
+          //} else {
             const response = await this.es.countEvents(this.es.esIndexAlarmEvent, alarmID, r['stage']);
             r['events_count'] = response.count;
-          }
+          // }
         }));
       }));
     } catch (err) {


### PR DESCRIPTION
This adds: ```"all_rules_always_active": bool``` option to directive files, which defaults to ```false``` if not defined. The goal is to reduce unnecessary new backlog creation and to consolidate relevant events to  a single alarm.

Setting that flag to ```true``` will change the respective directive rule processing in this manner:
1. Incoming events that don't match the current backlog stage rule will be evaluated against previous stage rule(s). Any match found in this context will only be added to the list of events for that (previous) rule, and will not affect the alarm risk calculation.
2. When a new backlog is created, ```ANY```, ```HOME_NET```, or ```!HOME_NET``` strings in the first rule's ```From``` and ```To``` keys will be replaced with the source/destination IPs of the first matching event. The intent here is to keep  the results of [1] above relevant to the backlog.