### PR TITLE
fix: missing VA check for the 1st matching event

### DIFF
--- a/internal/pkg/dsiem/alarm/helper.go
+++ b/internal/pkg/dsiem/alarm/helper.go
@@ -101,6 +101,10 @@ func copyAlarm(dst *alarm, src *alarm) {
 }
 
 func updateElasticsearch(a *alarm, checker string, connID uint64, tx *apm.Transaction) {
+	if a.Risk == 0 {
+		log.Debug(log.M{Msg: "Risk is 0, alarm not updating ES", CId: connID})
+		return
+	}
 	err := logToES(a, connID)
 	if err == nil {
 		if apm.Enabled() && tx != nil {

--- a/internal/pkg/dsiem/alarm/helper_test.go
+++ b/internal/pkg/dsiem/alarm/helper_test.go
@@ -27,7 +27,7 @@ func TestHelper(t *testing.T) {
 	initDirAndLog(t)
 	t.Logf("Enabling log test mode")
 	log.EnableTestingMode()
-	a := alarm{}
+	a := alarm{Risk: 1}
 	apm.Enable(true)
 	aLogFile = ""
 


### PR DESCRIPTION
This is true when the 2nd and subsequent rules never refer to the same IP/port combination in the first rule.
