### PR TITLE
chore: adjust wrong env var in cluster example

### DIFF
--- a/deployments/docker/docker-compose-cluster.yml
+++ b/deployments/docker/docker-compose-cluster.yml
@@ -66,7 +66,7 @@ services:
     image: defenxor/dsiem:latest
     environment:
       - DSIEM_MODE=cluster-backend
-      - DSIEM_NODE=dsiem-backend
+      - DSIEM_NODE=dsiem-backend-0
       - DSIEM_FRONTEND=http://dsiem:8080
       - DSIEM_MSQ=nats://dsiem-nats:4222
       - DSIEM_PORT=8081


### PR DESCRIPTION
[skip ci]