### PR TITLE
perf: queue incoming events from NATS client lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/allegro/bigcache v0.0.0-20181009050124-70fdb6c1fbb8
 	github.com/buaazp/fasthttprouter v0.1.1
 	github.com/dogenzaka/tsv v0.0.0-20150215104501-8e02e611b1fb
+	github.com/enriquebris/goconcurrentqueue v0.0.0-20190719205347-3e5689c24f05
 	github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072
 	github.com/gocarina/gocsv/v2 v2.0.0-20181026075406-cde31a6ec2a8
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/elastic/go-sysinfo v0.0.0-20190103140604-e68552284485 h1:k9Ac5c19ZDF7
 github.com/elastic/go-sysinfo v0.0.0-20190103140604-e68552284485/go.mod h1:5kYRMF9nitZzZ4odJqSHV1DddYPTJ+QB4YsyWmNyJzA=
 github.com/elastic/go-windows v0.0.0-20180831131045-bb1581babc04 h1:6iBgytvH10GM0SRPYDAfFLV5Lx43a063hCi4GWil98I=
 github.com/elastic/go-windows v0.0.0-20180831131045-bb1581babc04/go.mod h1:jgPEIvw0E137UFC4zfkcjyM9T9shDL+JIfqFXQQhVwc=
+github.com/enriquebris/goconcurrentqueue v0.0.0-20190719205347-3e5689c24f05 h1:qiqZNItjRijX/MSnM+I+fW14fWL/h8TyrbetmRVmuHA=
+github.com/enriquebris/goconcurrentqueue v0.0.0-20190719205347-3e5689c24f05/go.mod h1:wGJhQNFI4wLNHleZLo5ehk1puj8M6OIl0tOjs3kwJus=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072 h1:DddqAaWDpywytcG8w/qoQ5sAN8X12d3Z3koB0C3Rxsc=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fortytw2/leaktest v1.2.0 h1:cj6GCiwJDH7l3tMHLjZDo0QqPtrXJiWSI9JgpeQKw+Q=

--- a/internal/pkg/dsiem/siem/eventqueue.go
+++ b/internal/pkg/dsiem/siem/eventqueue.go
@@ -1,0 +1,70 @@
+package siem
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/defenxor/dsiem/internal/pkg/dsiem/event"
+	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
+	"github.com/enriquebris/goconcurrentqueue"
+)
+
+type evtChan struct {
+	dirID int
+	ch    chan event.NormalizedEvent
+}
+
+type eventQueue struct {
+	q        *goconcurrentqueue.FIFO
+	bufChans []evtChan
+}
+
+func (eq *eventQueue) init(target []evtChan) {
+	eq.q = goconcurrentqueue.NewFIFO()
+	listener := func(i int) {
+		for {
+			e := <-eq.bufChans[i].ch
+			select {
+			case target[i].ch <- e:
+			case <-time.After(10 * time.Second):
+				log.Error(log.M{Msg: "Timeout sending event to directive " + strconv.Itoa(eq.bufChans[i].dirID) + "!"})
+			}
+		}
+	}
+	for i := range target {
+		eq.bufChans = append(eq.bufChans, evtChan{
+			ch:    make(chan event.NormalizedEvent),
+			dirID: target[i].dirID,
+		})
+		go listener(i)
+	}
+}
+
+func (eq *eventQueue) dequeue() {
+	for {
+		res, err := eq.q.DequeueOrWaitForNextElement()
+		if err != nil {
+			log.Error(log.M{Msg: "Error occur while dequeing event"})
+			continue
+		}
+		evt := res.(event.NormalizedEvent)
+		for i := range eq.bufChans {
+			eq.bufChans[i].ch <- evt
+		}
+	}
+}
+
+func (eq *eventQueue) enqueue(evt event.NormalizedEvent) {
+	err := eq.q.Enqueue(evt)
+	if err != nil {
+		log.Error(log.M{Msg: "Cannot enqueue event " + evt.EventID})
+	}
+}
+
+func (eq *eventQueue) reporter() {
+	ticker := time.NewTicker(30 * time.Second)
+	for {
+		<-ticker.C
+		log.Debug(log.M{Msg: "Queue length: " + strconv.Itoa(eq.q.GetLen())})
+	}
+}

--- a/vendor/github.com/enriquebris/goconcurrentqueue/.travis.yml
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+go:
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - go test -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/enriquebris/goconcurrentqueue/error.go
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/error.go
@@ -1,0 +1,29 @@
+package goconcurrentqueue
+
+const (
+	QueueErrorCodeEmptyQueue            = "empty-queue"
+	QueueErrorCodeLockedQueue           = "locked-queue"
+	QueueErrorCodeIndexOutOfBounds      = "index-out-of-bounds"
+	QueueErrorCodeFullCapacity          = "full-capacity"
+	QueueErrorCodeInternalChannelClosed = "internal-channel-closed"
+)
+
+type QueueError struct {
+	code    string
+	message string
+}
+
+func NewQueueError(code string, message string) *QueueError {
+	return &QueueError{
+		code:    code,
+		message: message,
+	}
+}
+
+func (st *QueueError) Error() string {
+	return st.message
+}
+
+func (st *QueueError) Code() string {
+	return st.code
+}

--- a/vendor/github.com/enriquebris/goconcurrentqueue/fifo_queue.go
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/fifo_queue.go
@@ -1,0 +1,221 @@
+package goconcurrentqueue
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	WaitForNextElementChanCapacity           = 1000
+	dequeueOrWaitForNextElementInvokeGapTime = 10
+)
+
+// FIFO (First In First Out) concurrent queue
+type FIFO struct {
+	slice       []interface{}
+	rwmutex     sync.RWMutex
+	lockRWmutex sync.RWMutex
+	isLocked    bool
+	// queue for watchers that will wait for next elements (if queue is empty at DequeueOrWaitForNextElement execution )
+	waitForNextElementChan chan chan interface{}
+}
+
+// NewFIFO returns a new FIFO concurrent queue
+func NewFIFO() *FIFO {
+	ret := &FIFO{}
+	ret.initialize()
+
+	return ret
+}
+
+func (st *FIFO) initialize() {
+	st.slice = make([]interface{}, 0)
+	st.waitForNextElementChan = make(chan chan interface{}, WaitForNextElementChanCapacity)
+}
+
+// Enqueue enqueues an element. Returns error if queue is locked.
+func (st *FIFO) Enqueue(value interface{}) error {
+	if st.isLocked {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	// check if there is a listener waiting for the next element (this element)
+	select {
+	case listener := <-st.waitForNextElementChan:
+		// send the element through the listener's channel instead of enqueue it
+		select {
+		case listener <- value:
+		default:
+			// enqueue if listener is not ready
+
+			// lock the object to enqueue the element into the slice
+			st.rwmutex.Lock()
+			// enqueue the element
+			st.slice = append(st.slice, value)
+			defer st.rwmutex.Unlock()
+		}
+
+	default:
+		// lock the object to enqueue the element into the slice
+		st.rwmutex.Lock()
+		// enqueue the element
+		st.slice = append(st.slice, value)
+		defer st.rwmutex.Unlock()
+	}
+
+	return nil
+}
+
+// Dequeue dequeues an element. Returns error if queue is locked or empty.
+func (st *FIFO) Dequeue() (interface{}, error) {
+	if st.isLocked {
+		return nil, NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	st.rwmutex.Lock()
+	defer st.rwmutex.Unlock()
+
+	len := len(st.slice)
+	if len == 0 {
+		return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue")
+	}
+
+	elementToReturn := st.slice[0]
+	st.slice = st.slice[1:]
+
+	return elementToReturn, nil
+}
+
+// DequeueOrWaitForNextElement dequeues an element (if exist) or waits until the next element gets enqueued and returns it.
+// Multiple calls to DequeueOrWaitForNextElement() would enqueue multiple "listeners" for future enqueued elements.
+func (st *FIFO) DequeueOrWaitForNextElement() (interface{}, error) {
+	for {
+		if st.isLocked {
+			return nil, NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+		}
+
+		// get the slice's len
+		st.rwmutex.Lock()
+		length := len(st.slice)
+		st.rwmutex.Unlock()
+
+		if length == 0 {
+			// channel to wait for next enqueued element
+			waitChan := make(chan interface{})
+
+			select {
+			// enqueue a watcher into the watchForNextElementChannel to wait for the next element
+			case st.waitForNextElementChan <- waitChan:
+
+				// re-checks every i milliseconds (top: 10 times) ... the following verifies if an item was enqueued
+				// around the same time DequeueOrWaitForNextElement was invoked, meaning the waitChan wasn't yet sent over
+				// st.waitForNextElementChan
+				for i := 0; i < dequeueOrWaitForNextElementInvokeGapTime; i++ {
+					select {
+					case dequeuedItem := <-waitChan:
+						return dequeuedItem, nil
+					case <-time.After(time.Millisecond * time.Duration(i)):
+						if dequeuedItem, err := st.Dequeue(); err == nil {
+							return dequeuedItem, nil
+						}
+					}
+				}
+
+				// return the next enqueued element, if any
+				return <-waitChan, nil
+			default:
+				// too many watchers (waitForNextElementChanCapacity) enqueued waiting for next elements
+				return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue and can't wait for next element because there are too many DequeueOrWaitForNextElement() waiting")
+			}
+		}
+
+		st.rwmutex.Lock()
+
+		// verify that at least 1 item resides on the queue
+		if len(st.slice) == 0 {
+			st.rwmutex.Unlock()
+			continue
+		}
+		elementToReturn := st.slice[0]
+		st.slice = st.slice[1:]
+
+		st.rwmutex.Unlock()
+		return elementToReturn, nil
+	}
+}
+
+// Get returns an element's value and keeps the element at the queue
+func (st *FIFO) Get(index int) (interface{}, error) {
+	if st.isLocked {
+		return nil, NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	st.rwmutex.RLock()
+	defer st.rwmutex.RUnlock()
+
+	if len(st.slice) <= index {
+		return nil, NewQueueError(QueueErrorCodeIndexOutOfBounds, fmt.Sprintf("index out of bounds: %v", index))
+	}
+
+	return st.slice[index], nil
+}
+
+// Remove removes an element from the queue
+func (st *FIFO) Remove(index int) error {
+	if st.isLocked {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	st.rwmutex.Lock()
+	defer st.rwmutex.Unlock()
+
+	if len(st.slice) <= index {
+		return NewQueueError(QueueErrorCodeIndexOutOfBounds, fmt.Sprintf("index out of bounds: %v", index))
+	}
+
+	// remove the element
+	st.slice = append(st.slice[:index], st.slice[index+1:]...)
+
+	return nil
+}
+
+// GetLen returns the number of enqueued elements
+func (st *FIFO) GetLen() int {
+	st.rwmutex.RLock()
+	defer st.rwmutex.RUnlock()
+
+	return len(st.slice)
+}
+
+// GetCap returns the queue's capacity
+func (st *FIFO) GetCap() int {
+	st.rwmutex.RLock()
+	defer st.rwmutex.RUnlock()
+
+	return cap(st.slice)
+}
+
+// Lock // Locks the queue. No enqueue/dequeue operations will be allowed after this point.
+func (st *FIFO) Lock() {
+	st.lockRWmutex.Lock()
+	defer st.lockRWmutex.Unlock()
+
+	st.isLocked = true
+}
+
+// Unlock unlocks the queue
+func (st *FIFO) Unlock() {
+	st.lockRWmutex.Lock()
+	defer st.lockRWmutex.Unlock()
+
+	st.isLocked = false
+}
+
+// IsLocked returns true whether the queue is locked
+func (st *FIFO) IsLocked() bool {
+	st.lockRWmutex.RLock()
+	defer st.lockRWmutex.RUnlock()
+
+	return st.isLocked
+}

--- a/vendor/github.com/enriquebris/goconcurrentqueue/fixed_fifo_queue.go
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/fixed_fifo_queue.go
@@ -1,0 +1,132 @@
+package goconcurrentqueue
+
+// Fixed capacity FIFO (First In First Out) concurrent queue
+type FixedFIFO struct {
+	queue    chan interface{}
+	lockChan chan struct{}
+	// queue for watchers that will wait for next elements (if queue is empty at DequeueOrWaitForNextElement execution )
+	waitForNextElementChan chan chan interface{}
+}
+
+func NewFixedFIFO(capacity int) *FixedFIFO {
+	queue := &FixedFIFO{}
+	queue.initialize(capacity)
+
+	return queue
+}
+
+func (st *FixedFIFO) initialize(capacity int) {
+	st.queue = make(chan interface{}, capacity)
+	st.lockChan = make(chan struct{}, 1)
+	st.waitForNextElementChan = make(chan chan interface{}, WaitForNextElementChanCapacity)
+}
+
+// Enqueue enqueues an element. Returns error if queue is locked or it is at full capacity.
+func (st *FixedFIFO) Enqueue(value interface{}) error {
+	if st.IsLocked() {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	// check if there is a listener waiting for the next element (this element)
+	select {
+	case listener := <-st.waitForNextElementChan:
+		// send the element through the listener's channel instead of enqueue it
+		listener <- value
+
+	default:
+		// enqueue the element following the "normal way"
+		select {
+		case st.queue <- value:
+		default:
+			return NewQueueError(QueueErrorCodeFullCapacity, "FixedFIFO queue is at full capacity")
+		}
+	}
+
+	return nil
+}
+
+// Dequeue dequeues an element. Returns error if: queue is locked, queue is empty or internal channel is closed.
+func (st *FixedFIFO) Dequeue() (interface{}, error) {
+	if st.IsLocked() {
+		return nil, NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	select {
+	case value, ok := <-st.queue:
+		if ok {
+			return value, nil
+		}
+		return nil, NewQueueError(QueueErrorCodeInternalChannelClosed, "internal channel is closed")
+	default:
+		return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue")
+	}
+}
+
+// DequeueOrWaitForNextElement dequeues an element (if exist) or waits until the next element gets enqueued and returns it.
+// Multiple calls to DequeueOrWaitForNextElement() would enqueue multiple "listeners" for future enqueued elements.
+func (st *FixedFIFO) DequeueOrWaitForNextElement() (interface{}, error) {
+	if st.IsLocked() {
+		return nil, NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	select {
+	case value, ok := <-st.queue:
+		if ok {
+			return value, nil
+		}
+		return nil, NewQueueError(QueueErrorCodeInternalChannelClosed, "internal channel is closed")
+
+	// queue is empty, add a listener to wait until next enqueued element is ready
+	default:
+		// channel to wait for next enqueued element
+		waitChan := make(chan interface{})
+
+		select {
+		// enqueue a watcher into the watchForNextElementChannel to wait for the next element
+		case st.waitForNextElementChan <- waitChan:
+			// return the next enqueued element, if any
+			return <-waitChan, nil
+		default:
+			// too many watchers (waitForNextElementChanCapacity) enqueued waiting for next elements
+			return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue and can't wait for next element")
+		}
+
+		//return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue")
+	}
+}
+
+// GetLen returns queue's length (total enqueued elements)
+func (st *FixedFIFO) GetLen() int {
+	st.Lock()
+	defer st.Unlock()
+
+	return len(st.queue)
+}
+
+// GetCap returns the queue's capacity
+func (st *FixedFIFO) GetCap() int {
+	st.Lock()
+	defer st.Unlock()
+
+	return cap(st.queue)
+}
+
+func (st *FixedFIFO) Lock() {
+	// non-blocking fill the channel
+	select {
+	case st.lockChan <- struct{}{}:
+	default:
+	}
+}
+
+func (st *FixedFIFO) Unlock() {
+	// non-blocking flush the channel
+	select {
+	case <-st.lockChan:
+	default:
+	}
+}
+
+func (st *FixedFIFO) IsLocked() bool {
+	return len(st.lockChan) >= 1
+}

--- a/vendor/github.com/enriquebris/goconcurrentqueue/queue.go
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/queue.go
@@ -1,0 +1,23 @@
+package goconcurrentqueue
+
+// Queue interface with basic && common queue functions
+type Queue interface {
+	// Enqueue element
+	Enqueue(interface{}) error
+	// Dequeue element
+	Dequeue() (interface{}, error)
+	// DequeueOrWaitForNextElement dequeues an element (if exist) or waits until the next element gets enqueued and returns it.
+	// Multiple calls to DequeueOrWaitForNextElement() would enqueue multiple "listeners" for future enqueued elements.
+	DequeueOrWaitForNextElement() (interface{}, error)
+	// Get number of enqueued elements
+	GetLen() int
+	// Get queue's capacity
+	GetCap() int
+
+	// Lock the queue. No enqueue/dequeue/remove/get operations will be allowed after this point.
+	Lock()
+	// Unlock the queue.
+	Unlock()
+	// Return true whether the queue is locked
+	IsLocked() bool
+}

--- a/vendor/github.com/enriquebris/goconcurrentqueue/readme.md
+++ b/vendor/github.com/enriquebris/goconcurrentqueue/readme.md
@@ -1,0 +1,233 @@
+[![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/enriquebris/goconcurrentqueue) ![version](https://img.shields.io/badge/version-v0.5.1-yellowgreen.svg?style=flat "goconcurrentqueue v0.5.1")  [![Go Report Card](https://goreportcard.com/badge/github.com/enriquebris/goconcurrentqueue)](https://goreportcard.com/report/github.com/enriquebris/goconcurrentqueue)  [![Build Status](https://api.travis-ci.org/enriquebris/goconcurrentqueue.svg?branch=master)](https://travis-ci.org/enriquebris/goconcurrentqueue) [![codecov](https://codecov.io/gh/enriquebris/goconcurrentqueue/branch/master/graph/badge.svg)](https://codecov.io/gh/enriquebris/goconcurrentqueue)
+
+# goconcurrentqueue - Concurrent safe queues
+The package goconcurrentqueue offers a public interface Queue with methods for a [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)).
+It comes with multiple Queue's concurrent-safe implementations, meaning they could be used concurrently by multiple goroutines without adding race conditions.
+
+## Topics
+ - [Installation](#installation)
+ - [Documentation](#documentation)
+ - [Queues](#queues)
+    - [FIFO](#fifo)
+    - [FixedFIFO](#fixedfifo)
+    - [Benchmarks](#benchmarks-fixedfifo-vs-fifo)
+ - [Get started](#get-started)
+ - [History](#history)
+
+## Installation
+
+Execute
+```bash
+go get github.com/enriquebris/goconcurrentqueue
+```
+
+This package is compatible with the following golang versions:
+ - 1.7.x
+ - 1.8.x
+ - 1.9.x
+ - 1.10.x
+ - 1.11.x
+ - 1.12.x
+
+## Documentation
+Visit [goconcurrentqueue at godoc.org](https://godoc.org/github.com/enriquebris/goconcurrentqueue)
+
+## Queues
+
+- First In First Out (FIFO)
+    - [FIFO](#fifo)
+    - [FixedFIFO](#fixedfifo)
+    - [Benchmarks FixedFIFO vs FIFO](#benchmarks-fixedfifo-vs-fifo)
+
+### FIFO
+
+**FIFO**: concurrent-safe auto expandable queue.
+
+#### pros
+ - It is possible to enqueue as many items as needed.
+ - Extra methods to get and remove enqueued items:
+     - [Get](https://godoc.org/github.com/enriquebris/goconcurrentqueue#FIFO.Get): returns an element's value and keeps the element at the queue
+     - [Remove](https://godoc.org/github.com/enriquebris/goconcurrentqueue#FIFO.Get): removes an element (using a given position) from the queue
+
+#### cons
+ - It is slightly slower than FixedFIFO.
+
+### FixedFIFO
+
+**FixedFIFO**: concurrent-safe fixed capacity queue.
+
+#### pros
+ - FixedFIFO is, at least, 2x faster than [FIFO](#fifo) in concurrent scenarios (multiple GR accessing the queue simultaneously).
+
+#### cons
+ - It has a fixed capacity meaning that no more items than this capacity could coexist at the same time. 
+
+## Benchmarks FixedFIFO vs FIFO
+
+The numbers for the following charts were obtained by running the benchmarks in a 2012 MacBook Pro (2.3 GHz Intel Core i7 - 16 GB 1600 MHz DDR3) with golang v1.12 
+
+### Enqueue
+
+![concurrent-safe FixedFIFO vs FIFO . operation: enqueue](web/FixedFIFO-vs-FIFO-enqueue.png "concurrent-safe FixedFIFO vs FIFO . operation: enqueue")
+
+### Dequeue
+
+![concurrent-safe FixedFIFO vs FIFO . operation: dequeue](web/FixedFIFO-vs-FIFO-dequeue.png "concurrent-safe FixedFIFO vs FIFO . operation: dequeue")
+
+## Get started
+
+### FIFO queue simple usage
+[Live code - playground](https://play.golang.org/p/CRhg7kX0ikH)
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/enriquebris/goconcurrentqueue"
+)
+
+type AnyStruct struct {
+	Field1 string
+	Field2 int
+}
+
+func main() {
+	queue := goconcurrentqueue.NewFIFO()
+
+	queue.Enqueue("any string value")
+	queue.Enqueue(5)
+	queue.Enqueue(AnyStruct{Field1: "hello world", Field2: 15})
+
+	// will output: 3
+	fmt.Printf("queue's length: %v\n", queue.GetLen())
+
+	item, err := queue.Dequeue()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// will output "any string value"
+	fmt.Printf("dequeued item: %v\n", item)
+
+	// will output: 2
+	fmt.Printf("queue's length: %v\n", queue.GetLen())
+
+}
+```
+
+### Wait until an element gets enqueued
+[Live code - playground](https://play.golang.org/p/S7oSg3iUNhs)
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/enriquebris/goconcurrentqueue"
+)
+
+func main() {
+	var (
+		fifo = goconcurrentqueue.NewFIFO()
+		done = make(chan struct{})
+	)
+
+	go func() {
+		fmt.Println("1 - Waiting for next enqueued element")
+		value, _ := fifo.DequeueOrWaitForNextElement()
+		fmt.Printf("2 - Dequeued element: %v\n", value)
+
+		done <- struct{}{}
+	}()
+
+	fmt.Println("3 - Go to sleep for 3 seconds")
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("4 - Enqueue element")
+	fifo.Enqueue(100)
+
+	<-done
+}
+
+```
+
+### Dependency Inversion Principle using concurrent-safe queues
+
+*High level modules should not depend on low level modules. Both should depend on abstractions.* Robert C. Martin
+
+[Live code - playground](https://play.golang.org/p/3GAbyR7wrX7)
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/enriquebris/goconcurrentqueue"
+)
+
+func main() {
+	var (
+		queue          goconcurrentqueue.Queue
+		dummyCondition = true
+	)
+
+	// decides which Queue's implementation is the best option for this scenario
+	if dummyCondition {
+		queue = goconcurrentqueue.NewFIFO()
+	} else {
+		queue = goconcurrentqueue.NewFixedFIFO(10)
+	}
+
+	fmt.Printf("queue's length: %v\n", queue.GetLen())
+	workWithQueue(queue)
+	fmt.Printf("queue's length: %v\n", queue.GetLen())
+}
+
+// workWithQueue uses a goconcurrentqueue.Queue to perform the work
+func workWithQueue(queue goconcurrentqueue.Queue) error {
+	// do some work
+
+	// enqueue an item
+	if err := queue.Enqueue("test value"); err != nil {
+		return err
+	}
+
+	return nil
+}
+```
+
+## History
+
+### v0.5.1
+
+- FIFO.DequeueOrWaitForNextElement() was modified to avoid deadlock when DequeueOrWaitForNextElement && Enqueue are invoked around the same time.
+- Added multiple goroutine unit testings for FIFO.DequeueOrWaitForNextElement() 
+
+### v0.5.0
+
+- Added DequeueOrWaitForNextElement()
+
+### v0.4.0
+
+- Added QueueError (custom error)
+
+### v0.3.0
+
+- Added FixedFIFO queue's implementation (at least 2x faster than FIFO for multiple GRs)
+- Added benchmarks for both FIFO / FixedFIFO
+- Added GetCap() to Queue interface
+- Removed Get() and Remove() methods from Queue interface
+
+### v0.2.0
+
+- Added Lock/Unlock/IsLocked methods to control operations locking
+
+### v0.1.0
+
+- First In First Out (FIFO) queue added


### PR DESCRIPTION
This change prevent NATS client lib from triggering slow consumer err, and also prevent deadlock in a single directive from stalling the entire pipeline.