### PR TITLE
fix: prevent used event from creating a backlog

### DIFF
--- a/internal/pkg/dsiem/siem/backlogmgr.go
+++ b/internal/pkg/dsiem/siem/backlogmgr.go
@@ -185,20 +185,22 @@ mainLoop:
 			continue mainLoop // back to chan loop
 		}
 
-		// compare the event against all backlogs starting event ID to prevent duplicates
+		// compare the event against all backlogs event ID to prevent duplicates
 		// due to concurrency
 		blogs.Lock()
 		for _, v := range blogs.bl {
-			for _, j := range v.Directive.Rules[0].Events {
-				if j == evt.EventID {
-					log.Info(log.M{Msg: "skipping backlog creation for event " + j +
-						", it's already used in backlog " + v.ID})
-					if apm.Enabled() && tx != nil {
-						tx.Result("Event already used in backlog" + v.ID)
-						tx.End()
+			for _, y := range v.Directive.Rules {
+				for _, j := range y.Events {
+					if j == evt.EventID {
+						log.Info(log.M{Msg: "skipping backlog creation for event " + j +
+							", it's already used in backlog " + v.ID})
+						if apm.Enabled() && tx != nil {
+							tx.Result("Event already used in backlog" + v.ID)
+							tx.End()
+						}
+						blogs.Unlock()
+						continue mainLoop // back to chan loop
 					}
-					blogs.Unlock()
-					continue mainLoop // back to chan loop
 				}
 			}
 		}

--- a/internal/pkg/dsiem/siem/backlogmgr_test.go
+++ b/internal/pkg/dsiem/siem/backlogmgr_test.go
@@ -145,6 +145,7 @@ func TestBacklogMgr(t *testing.T) {
 
 	fmt.Print("3rd event, will also fail updating ES ..")
 	e.ConnID = 3
+	e.EventID = "3"
 	bLogFileMutex.Lock()
 	bLogFile = ""
 	bLogFileMutex.Unlock()
@@ -155,12 +156,13 @@ func TestBacklogMgr(t *testing.T) {
 
 	fmt.Print("4th event ..")
 	e.ConnID = 4
+	e.EventID = "4"
 	verifyEventOutput(t, e, ch, "stage increased")
 
 	// this should create new backlog
 	fmt.Print("5th event ..")
 	e.ConnID = 5
-	e.EventID = "2"
+	e.EventID = "5"
 	e.SrcIP = "192.168.0.1"
 	e.DstIP = "192.168.0.3"
 	verifyEventOutput(t, e, ch, "Creating new backlog")
@@ -182,6 +184,7 @@ func TestBacklogMgr(t *testing.T) {
 	fmt.Print("7th event ..")
 	e.PluginSID = 31337
 	e.ConnID = 7
+	e.EventID = "7"
 	verifyEventOutput(t, e, ch, "backlog doeseventmatch false")
 
 	var blID string


### PR DESCRIPTION
previously this check is only done against the first event, but it makes more sense to do it against all

[skip release]