### PR TITLE
fix: unused function call causes frontend mode to crash

### DIFF
--- a/internal/pkg/dsiem/expcounter/counter.go
+++ b/internal/pkg/dsiem/expcounter/counter.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/defenxor/dsiem/internal/pkg/dsiem/alarm"
 	"github.com/defenxor/dsiem/internal/pkg/dsiem/siem"
 
 	"github.com/defenxor/dsiem/internal/pkg/dsiem/server"
@@ -63,7 +62,6 @@ func startTicker(mode string, once bool) {
 		time.Sleep(5 * time.Second)
 	}
 	countGoroutine() // not used in the loop for now
-	countAlarm()     // same as countGoroutine
 	for {
 		var e, b, m string
 		<-ticker.C
@@ -96,11 +94,13 @@ func countGoroutine() string {
 	return strconv.Itoa(r)
 }
 
+/*
 func countAlarm() string {
 	a := alarm.Count()
 	alarmCounter.Set(int64(a))
 	return strconv.Itoa(a)
 }
+*/
 
 func countBacklogs() string {
 	b, act, ttl := siem.CountBackLogs()

--- a/internal/pkg/dsiem/expcounter/counter_test.go
+++ b/internal/pkg/dsiem/expcounter/counter_test.go
@@ -17,7 +17,6 @@
 package expcounter
 
 import (
-	"github.com/defenxor/dsiem/internal/pkg/dsiem/alarm"
 	"time"
 
 	"testing"
@@ -33,7 +32,7 @@ func TestInit(t *testing.T) {
 	viper.Set("tags", []string{"0"})
 	viper.Set("status", []string{"Open"})
 	// server.InitRcCounter()
-	alarm.Init("doesntmatter", false)
+	// alarm.Init("doesntmatter", false)
 	Init("standalone")
 	startTicker("standalone", true)
 	time.Sleep(6 * time.Second)


### PR DESCRIPTION
expcounter.countAlarm() isn't supposed to be used in frontend mode.
infact it's no longer used anywhere so this change comment it out for now.