### PR TITLE
fix: loose regex in filename validation

### DIFF
--- a/internal/pkg/dsiem/server/server_test.go
+++ b/internal/pkg/dsiem/server/server_test.go
@@ -205,8 +205,14 @@ func TestServerStartupAndFileServer(t *testing.T) {
 	httpTest(t, url+"/config/", "GET", "", 200)
 	httpTest(t, url+"/config/intel_wise.json", "GET", "", 200)
 	httpTest(t, url+"/config/doesntexist.json", "GET", "", 400)
+	httpTest(t, url+"/config/a.json", "GET", "", 400)
 	httpTest(t, url+"/config/payload.exe", "GET", "", 418)
 	httpTest(t, url+"/config/dir/asdad/", "GET", "", 404)
+
+	httpTest(t, url+"/config/test.json.foo", "GET", "", 418)
+	httpTest(t, url+"/config/..dot_in_fname.json", "GET", "", 418)
+	httpTest(t, url+"/config/ʘunicode.json", "GET", "", 418)
+	httpTest(t, url+"/config/_.json", "GET", "", 418)
 
 	stopServer(t)
 

--- a/internal/pkg/dsiem/server/validate.go
+++ b/internal/pkg/dsiem/server/validate.go
@@ -28,7 +28,7 @@ import (
 )
 
 func isCfgFileNameValid(filename string) (ok bool) {
-	r, err := regexp.Compile(`[a-zA-Z0-9_-]+.json`)
+	r, err := regexp.Compile(`^[a-zA-Z0-9]([a-zA-Z0-9_-]+)?.json$`)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
this tighten it so we dont just rely on the http router for protection.
