### PR TITLE
improv: refactor dirmaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 node_modules/
 # alienvault rules
 *.tsv
+!*plugin-sid-test.tsv
 user.xml
 user.xml.tmp
 
@@ -38,3 +39,6 @@ logs
 !demo/frontend/web/.vscode/
 
 test_directives
+dev_*
+
+.DS_STORE

--- a/internal/pkg/dpluger/dirmaker.go
+++ b/internal/pkg/dpluger/dirmaker.go
@@ -55,15 +55,17 @@ func CreateDirective(tsvFile, outFile, kingdom, titleTemplate string, priority, 
 	return fs.OverwriteFileValueIndent(dirs, outFile)
 }
 
-func createDirective(f1 io.Reader, dirs siem.Directives, kingdom, titleTemplate string, priority,
+func createDirective(in io.Reader, dirs siem.Directives, kingdom, titleTemplate string, priority,
 	reliability, dirNumber int) (siem.Directives, error) {
 
 	t := tsvEntries{}
 	rec := pluginSIDRef{}
-	parser, err := tsv.NewParser(f1, &rec)
+	parser, err := tsv.NewParser(in, &rec)
 	if err != nil {
 		return dirs, err
 	}
+
+	parser.Reader.LazyQuotes = true
 
 	for {
 		eof, err := parser.Next()

--- a/internal/pkg/dpluger/dirmaker_test.go
+++ b/internal/pkg/dpluger/dirmaker_test.go
@@ -64,9 +64,9 @@ func TestOptionalKingdom(t *testing.T) {
 	)
 
 	in := strings.NewReader(`plugin	id	sid	title	category	kingdom
-suricata	9001	2011207	SaschArt SasCam Webcam Server ActiveX Control Head Method Buffer Overflow Attempt	Web Application Attack
-suricata	9001	2010943	SoftCab Sound Converter ActiveX SaveFormat File overwrite Attempt	Web Application Attack	TEST
-suricata	9001	2008791	Visagesoft eXPert PDF Viewer ActiveX Control Arbitrary File Overwrite	Web Application Attack`)
+test	1337	1337001	Directive 1	Testing Directive
+test	1337	1337002	Directive 2 with Kingdom	Testing Directive 2	TEST
+test	1337	1337003	Directive 3	Testing Directive 3`)
 
 	var dirs siem.Directives
 	var err error
@@ -75,5 +75,115 @@ suricata	9001	2008791	Visagesoft eXPert PDF Viewer ActiveX Control Arbitrary Fil
 		t.Fatal(err.Error())
 	}
 
-	_ = dirs
+	if len(dirs.Dirs) != 3 {
+		t.Fatalf("expected 3 new directives, but got %d", len(dirs.Dirs))
+	}
+
+	dir := dirs.Dirs[0]
+	if dir.Name != "Directive 1 (SRC_IP to DST_IP)" {
+		t.Errorf("expected first directive name to be '%s' but got '%s'", "Directive 1 (SRC_IP to DST_IP)", dir.Name)
+	}
+
+	if dir.Category != "Testing Directive" {
+		t.Errorf("expected first directive name to be '%s' but got '%s'", "Testing Directive", dir.Category)
+	}
+
+	if dir.ID != 100000 {
+		t.Errorf("expected first directive ID to be %d but got %d", 100000, dir.ID)
+	}
+
+	for _, rule := range dir.Rules {
+		var foundSID bool
+		for _, id := range rule.PluginSID {
+			if id == 1337001 {
+				foundSID = true
+				break
+			}
+		}
+
+		if !foundSID {
+			t.Errorf("expected plugin rules to contain sid %d", 1337001)
+		}
+
+		if rule.PluginID != 1337 {
+			t.Errorf("expected rule plugin ID to be %d but got %d", 1337, rule.PluginID)
+		}
+	}
+
+	if dir.Kingdom != kingdom {
+		t.Errorf("expected first directive kingdom to be '%s' but got '%s'", kingdom, dir.Kingdom)
+	}
+
+	// check second rule
+	dir = dirs.Dirs[1]
+	if dir.Name != "Directive 2 with Kingdom (SRC_IP to DST_IP)" {
+		t.Errorf("expected second directive name to be '%s' but got '%s'", "Directive 2 with Kingdom (SRC_IP to DST_IP)", dir.Name)
+	}
+
+	if dir.Category != "Testing Directive 2" {
+		t.Errorf("expected second directive name to be '%s' but got '%s'", "Testing Directive 2", dir.Category)
+	}
+
+	if dir.ID != 100001 {
+		t.Errorf("expected second directive ID to be %d but got %d", 100001, dir.ID)
+	}
+
+	for _, rule := range dir.Rules {
+		var foundSID bool
+		for _, id := range rule.PluginSID {
+			if id == 1337002 {
+				foundSID = true
+				break
+			}
+		}
+
+		if !foundSID {
+			t.Errorf("expected plugin rules to contain sid %d", 1337001)
+		}
+
+		if rule.PluginID != 1337 {
+			t.Errorf("expected rule plugin ID to be %d but got %d", 1337, rule.PluginID)
+		}
+	}
+
+	if dir.Kingdom != "TEST" {
+		t.Errorf("expected second directive kingdom to be '%s' but got '%s'", "TEST", dir.Kingdom)
+	}
+
+	// check third directive
+	dir = dirs.Dirs[2]
+	if dir.Name != "Directive 3 (SRC_IP to DST_IP)" {
+		t.Errorf("expected third directive name to be '%s' but got '%s'", "Directive 3 (SRC_IP to DST_IP)", dir.Name)
+	}
+
+	if dir.Category != "Testing Directive 3" {
+		t.Errorf("expected third directive name to be '%s' but got '%s'", "Testing Directive 3", dir.Category)
+	}
+
+	if dir.ID != 100002 {
+		t.Errorf("expected third directive ID to be %d but got %d", 100000, dir.ID)
+	}
+
+	for _, rule := range dir.Rules {
+		var foundSID bool
+		for _, id := range rule.PluginSID {
+			if id == 1337003 {
+				foundSID = true
+				break
+			}
+		}
+
+		if !foundSID {
+			t.Errorf("expected plugin rules to contain sid %d", 1337003)
+		}
+
+		if rule.PluginID != 1337 {
+			t.Errorf("expected rule plugin ID to be %d but got %d", 1337, rule.PluginID)
+		}
+	}
+
+	if dir.Kingdom != kingdom {
+		t.Errorf("expected third directive kingdom to be '%s' but got '%s'", kingdom, dir.Kingdom)
+	}
+
 }

--- a/internal/pkg/dpluger/dirmaker_test.go
+++ b/internal/pkg/dpluger/dirmaker_test.go
@@ -52,3 +52,28 @@ suricata	9001	2009041	SQLNinja MSSQL Database User Rights Scan	Attempted Informa
 
 	_ = dirs
 }
+
+func TestOptionalKingdom(t *testing.T) {
+	log.Setup(true)
+	const (
+		kingdom       = "DEFAULT"
+		titleTemplate = "EVENT_TITLE (SRC_IP to DST_IP)"
+		priority      = 3
+		reliability   = 1
+		dirnumber     = 100000
+	)
+
+	in := strings.NewReader(`plugin	id	sid	title	category	kingdom
+suricata	9001	2011207	SaschArt SasCam Webcam Server ActiveX Control Head Method Buffer Overflow Attempt	Web Application Attack
+suricata	9001	2010943	SoftCab Sound Converter ActiveX SaveFormat File overwrite Attempt	Web Application Attack	TEST
+suricata	9001	2008791	Visagesoft eXPert PDF Viewer ActiveX Control Arbitrary File Overwrite	Web Application Attack`)
+
+	var dirs siem.Directives
+	var err error
+	dirs, err = createDirective(in, dirs, kingdom, titleTemplate, priority, reliability, dirnumber)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_ = dirs
+}

--- a/internal/pkg/dpluger/dirmaker_test.go
+++ b/internal/pkg/dpluger/dirmaker_test.go
@@ -1,8 +1,10 @@
 package dpluger
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/defenxor/dsiem/internal/pkg/dsiem/siem"
 	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
 )
 
@@ -24,4 +26,29 @@ func TestCreateDirective(t *testing.T) {
 	}
 
 	// TODO: load the created directive here and validate.
+}
+
+func TestDirectiveDoubleQuoteTitle(t *testing.T) {
+	log.Setup(true)
+	const (
+		kingdom       = "DEFAULT"
+		titleTemplate = "EVENT_TITLE (SRC_IP to DST_IP)"
+		priority      = 3
+		reliability   = 1
+		dirnumber     = 100000
+	)
+
+	in := strings.NewReader(`plugin	id	sid	title	category
+suricata	9001	2009477	SQLBrute SQL Scan Detected	Attempted Information Leak
+suricata	9001	2009040	SQLNinja MSSQL User Scan"; content:"?param=a	Attempted Information Leak
+suricata	9001	2009041	SQLNinja MSSQL Database User Rights Scan	Attempted Information Leak`)
+
+	var dirs siem.Directives
+	var err error
+	dirs, err = createDirective(in, dirs, kingdom, titleTemplate, priority, reliability, dirnumber)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_ = dirs
 }

--- a/internal/pkg/dpluger/dirmaker_test.go
+++ b/internal/pkg/dpluger/dirmaker_test.go
@@ -26,7 +26,14 @@ func TestCreateDirective(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// TODO: load the created directive here and validate.
+	dirs, _, err := siem.LoadDirectivesFromFile("testdata", "dev_out-*.json", false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(dirs.Dirs) != 3 {
+		t.Fatalf("expected 3 directives, but got '%d'", len(dirs.Dirs))
+	}
 }
 
 func TestDirectiveDoubleQuoteTitle(t *testing.T) {
@@ -51,7 +58,9 @@ suricata	9001	2009041	SQLNinja MSSQL Database User Rights Scan	Attempted Informa
 		t.Fatal(err.Error())
 	}
 
-	_ = dirs
+	if len(dirs.Dirs) != 3 {
+		t.Fatalf("expected 3 directives, but got %d", len(dirs.Dirs))
+	}
 }
 
 func TestOptionalKingdom(t *testing.T) {

--- a/internal/pkg/dpluger/dirmaker_test.go
+++ b/internal/pkg/dpluger/dirmaker_test.go
@@ -1,0 +1,27 @@
+package dpluger
+
+import (
+	"testing"
+
+	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
+)
+
+func TestCreateDirective(t *testing.T) {
+	log.Setup(true)
+	const (
+		testdata      = "testdata/x_plugin-sid-test.tsv"
+		outfile       = "testdata/dev_out-test-x.json"
+		kingdom       = "TEST"
+		titleTemplate = "EVENT_TITLE (SRC_IP to DST_IP)"
+		priority      = 3
+		reliability   = 1
+		dirnumber     = 100000
+	)
+
+	err := CreateDirective(testdata, outfile, kingdom, titleTemplate, priority, reliability, dirnumber)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// TODO: load the created directive here and validate.
+}

--- a/internal/pkg/dpluger/testdata/x_plugin-sid-test.tsv
+++ b/internal/pkg/dpluger/testdata/x_plugin-sid-test.tsv
@@ -1,0 +1,4 @@
+plugin	id	sid	title	category
+test	1337	1337111	Directive Test 1	Testing Directive
+test	1337	1337112	Directive Test 2	Testing Directive
+test	1337	1337112	Directive Test 3	Testing Directive

--- a/internal/pkg/dpluger/tsvref.go
+++ b/internal/pkg/dpluger/tsvref.go
@@ -18,7 +18,6 @@ package dpluger
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path"
 	"sort"
@@ -53,34 +52,17 @@ func (ref *pluginSIDRef) fromStrings(defaultKingdom string, in ...string) error 
 	}
 
 	var err error
-	ref.ID, err = parseInt(in[1])
+	ref.ID, err = strconv.Atoi(in[1])
 	if err != nil {
 		return fmt.Errorf("can not parse plugin ID, %s", err.Error())
 	}
 
-	ref.SID, err = parseInt(in[2])
+	ref.SID, err = strconv.Atoi(in[2])
 	if err != nil {
 		return fmt.Errorf("can not parse plugin SID, %s", err.Error())
 	}
 
 	return nil
-}
-
-func parseInt(in string) (int, error) {
-	w, err := strconv.ParseInt(in, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	if w > math.MaxInt {
-		return 0, fmt.Errorf("input can not be larger than %d", math.MaxInt)
-	}
-
-	if w < 0 {
-		return 0, fmt.Errorf("input must be greater than 0")
-	}
-
-	return int(w), nil
 }
 
 type tsvRef struct {

--- a/internal/pkg/dpluger/tsvref.go
+++ b/internal/pkg/dpluger/tsvref.go
@@ -32,6 +32,7 @@ type pluginSIDRef struct {
 	SID      int    `tsv:"sid"`
 	SIDTitle string `tsv:"title"`
 	Category string `tsv:"category"`
+	Kingdom  string `tsv:"kingdom"`
 }
 
 type tsvRef struct {

--- a/internal/pkg/dpluger/tsvref.go
+++ b/internal/pkg/dpluger/tsvref.go
@@ -17,6 +17,7 @@
 package dpluger
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"sort"
@@ -33,6 +34,38 @@ type pluginSIDRef struct {
 	SIDTitle string `tsv:"title"`
 	Category string `tsv:"category"`
 	Kingdom  string `tsv:"kingdom"`
+}
+
+func (ref *pluginSIDRef) fromStrings(defaultKingdom string, in ...string) error {
+	if len(in) != 5 && len(in) != 6 {
+		return fmt.Errorf("expected 5-6 inputs, but got %d", len(in))
+	}
+
+	ref.Name = in[0]
+	ref.SIDTitle = in[3]
+	ref.Category = in[4]
+
+	if len(in) == 6 {
+		ref.Kingdom = in[5]
+	} else {
+		ref.Kingdom = defaultKingdom
+	}
+
+	var num int64
+	var err error
+	num, err = strconv.ParseInt(in[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid plugin id, %s", err.Error())
+	}
+
+	ref.ID = int(num)
+	num, err = strconv.ParseInt(in[2], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid plugin sid, %s", err.Error())
+	}
+
+	ref.SID = int(num)
+	return nil
 }
 
 type tsvRef struct {

--- a/internal/pkg/dpluger/tsvref.go
+++ b/internal/pkg/dpluger/tsvref.go
@@ -18,6 +18,7 @@ package dpluger
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"sort"
@@ -58,13 +59,27 @@ func (ref *pluginSIDRef) fromStrings(defaultKingdom string, in ...string) error 
 		return fmt.Errorf("invalid plugin id, %s", err.Error())
 	}
 
-	ref.ID = int(num)
+	if num > 0 && num < math.MaxInt {
+		ref.ID = int(num)
+	} else if num < 0 {
+		return fmt.Errorf("plugin ID must be bigger than 0, got %d", num)
+	} else if num > math.MaxInt {
+		return fmt.Errorf("plugin ID must be less than %d, got %d", math.MaxInt, num)
+	}
+
 	num, err = strconv.ParseInt(in[2], 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid plugin sid, %s", err.Error())
 	}
 
-	ref.SID = int(num)
+	if num > 0 && num < math.MaxInt {
+		ref.SID = int(num)
+	} else if num < 0 {
+		return fmt.Errorf("plugin ID must be bigger than 0, got %d", num)
+	} else if num > math.MaxInt {
+		return fmt.Errorf("plugin ID must be less than %d, got %d", math.MaxInt, num)
+	}
+
 	return nil
 }
 

--- a/internal/pkg/dpluger/tsvref.go
+++ b/internal/pkg/dpluger/tsvref.go
@@ -52,35 +52,35 @@ func (ref *pluginSIDRef) fromStrings(defaultKingdom string, in ...string) error 
 		ref.Kingdom = defaultKingdom
 	}
 
-	var num int64
 	var err error
-	num, err = strconv.ParseInt(in[1], 10, 64)
+	ref.ID, err = parseInt(in[1])
 	if err != nil {
-		return fmt.Errorf("invalid plugin id, %s", err.Error())
+		return fmt.Errorf("can not parse plugin ID, %s", err.Error())
 	}
 
-	if num > 0 && num < math.MaxInt {
-		ref.ID = int(num)
-	} else if num < 0 {
-		return fmt.Errorf("plugin ID must be bigger than 0, got %d", num)
-	} else if num > math.MaxInt {
-		return fmt.Errorf("plugin ID must be less than %d, got %d", math.MaxInt, num)
-	}
-
-	num, err = strconv.ParseInt(in[2], 10, 64)
+	ref.SID, err = parseInt(in[2])
 	if err != nil {
-		return fmt.Errorf("invalid plugin sid, %s", err.Error())
-	}
-
-	if num > 0 && num < math.MaxInt {
-		ref.SID = int(num)
-	} else if num < 0 {
-		return fmt.Errorf("plugin ID must be bigger than 0, got %d", num)
-	} else if num > math.MaxInt {
-		return fmt.Errorf("plugin ID must be less than %d, got %d", math.MaxInt, num)
+		return fmt.Errorf("can not parse plugin SID, %s", err.Error())
 	}
 
 	return nil
+}
+
+func parseInt(in string) (int, error) {
+	w, err := strconv.ParseInt(in, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	if w > math.MaxInt {
+		return 0, fmt.Errorf("input can not be larger than %d", math.MaxInt)
+	}
+
+	if w < 0 {
+		return 0, fmt.Errorf("input must be greater than 0")
+	}
+
+	return int(w), nil
 }
 
 type tsvRef struct {

--- a/internal/pkg/dsiem/siem/directive.go
+++ b/internal/pkg/dsiem/siem/directive.go
@@ -19,6 +19,7 @@ package siem
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -140,6 +141,10 @@ func isWhitelisted(ip string) (ret bool) {
 	return
 }
 
+var (
+	ErrNoDirectiveLoaded = errors.New("no directive loaded from the file")
+)
+
 // LoadDirectivesFromFile load directive from namePattern (glob) files in confDir
 func LoadDirectivesFromFile(confDir string, namePattern string, includeDisabled bool) (res Directives, totalFromFile int, err error) {
 	p := path.Join(confDir, namePattern)
@@ -170,17 +175,16 @@ func LoadDirectivesFromFile(confDir string, namePattern string, includeDisabled 
 			}
 			err = ValidateDirective(&d.Dirs[j], &res)
 			if err != nil {
-				log.Warn(log.M{Msg: "Skipping directive ID " +
-					strconv.Itoa(d.Dirs[j].ID) +
-					" '" + d.Dirs[j].Name + "' due to error: " + err.Error()})
+				log.Warn(log.M{Msg: fmt.Sprintf("Skipping directive ID %d '%s' due to error: %s", d.Dirs[j].ID, d.Dirs[j].Name, err.Error())})
 				continue
 			}
 			res.Dirs = append(res.Dirs, d.Dirs[j])
 		}
 	}
 	if len(res.Dirs) == 0 {
-		return res, 0, errors.New("Cannot load any directive from " + path.Join(confDir, namePattern))
+		return res, 0, ErrNoDirectiveLoaded
 	}
+
 	return
 }
 

--- a/internal/pkg/dsiem/siem/directive_test.go
+++ b/internal/pkg/dsiem/siem/directive_test.go
@@ -41,7 +41,7 @@ func TestInitDirective(t *testing.T) {
 	fDir := path.Join(testDir, "internal", "pkg", "dsiem", "siem", "fixtures")
 	evtChan := make(chan event.NormalizedEvent)
 	err := InitDirectives(path.Join(fDir, "directive2"), evtChan, 0, 1000, 0)
-	if err == nil || !strings.Contains(err.Error(), "Cannot load any directive from") {
+	if err == nil || !strings.Contains(err.Error(), "Cannot load any directive from") || err != ErrNoDirectiveLoaded {
 		t.Fatal(err)
 	}
 	err = InitDirectives(path.Join(fDir, "directive1"), evtChan, 0, 1000, 0)

--- a/internal/pkg/dsiem/siem/directive_test.go
+++ b/internal/pkg/dsiem/siem/directive_test.go
@@ -41,9 +41,15 @@ func TestInitDirective(t *testing.T) {
 	fDir := path.Join(testDir, "internal", "pkg", "dsiem", "siem", "fixtures")
 	evtChan := make(chan event.NormalizedEvent)
 	err := InitDirectives(path.Join(fDir, "directive2"), evtChan, 0, 1000, 0)
-	if err == nil || !strings.Contains(err.Error(), "Cannot load any directive from") || err != ErrNoDirectiveLoaded {
-		t.Fatal(err)
+
+	if err == nil {
+		t.Fatal("expected error")
 	}
+
+	if !strings.Contains(err.Error(), "Cannot load any directive from") || err != ErrNoDirectiveLoaded {
+		t.Fatalf("expected error telling no directive loaded, but got '%s'", err.Error())
+	}
+
 	err = InitDirectives(path.Join(fDir, "directive1"), evtChan, 0, 1000, 0)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pkg/dsiem/siem/directive_test.go
+++ b/internal/pkg/dsiem/siem/directive_test.go
@@ -19,7 +19,6 @@ package siem
 import (
 	"fmt"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -46,8 +45,8 @@ func TestInitDirective(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if !strings.Contains(err.Error(), "Cannot load any directive from") || err != ErrNoDirectiveLoaded {
-		t.Fatalf("expected error telling no directive loaded, but got '%s'", err.Error())
+	if err != ErrNoDirectiveLoaded {
+		t.Fatalf("expected error to be '%s' but got '%s'", ErrNoDirectiveLoaded.Error(), err.Error())
 	}
 
 	err = InitDirectives(path.Join(fDir, "directive1"), evtChan, 0, 1000, 0)

--- a/internal/pkg/nesd/server.go
+++ b/internal/pkg/nesd/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
@@ -58,7 +59,13 @@ func handler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	clientAddr := r.RemoteAddr
 	qv := r.URL.Query()
 	ip := qv.Get("ip")
+	ip = strings.Replace(ip, "\n", "", -1)
+	ip = strings.Replace(ip, "\r", "", -1)
+
 	port := qv.Get("port")
+	port = strings.Replace(port, "\n", "", -1)
+	port = strings.Replace(port, "\r", "", -1)
+
 	if ip == "" || port == "" {
 		http.Error(w, "requires ip and port parameter", 400)
 		log.Info(log.M{Msg: "returning 400-1"})

--- a/internal/pkg/shared/fs/fs.go
+++ b/internal/pkg/shared/fs/fs.go
@@ -17,6 +17,8 @@
 package fs
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"strings"
 
@@ -60,8 +62,43 @@ func OverwriteFile(s string, filename string) error {
 		return err
 	}
 	defer f.Close()
-	_, err = f.WriteString(s + "\n")
+	return Write(s, f)
+}
+
+func Write(s string, w io.StringWriter) error {
+	_, err := w.WriteString(s + "\n")
 	return err
+}
+
+// OverwriteFileBytes truncate filename and write b []bytes into it
+func OverwriteFileBytes(b []byte, filename string) error {
+	f, err := os.OpenFile(filename, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return WriteBytes(b, f)
+}
+
+func WriteBytes(b []byte, w io.Writer) error {
+	_, err := w.Write(b)
+	return err
+}
+
+// OverwriteFileValueIndent marshall v into indented json, then truncate the file filename and write the marshalled bytes into it
+func OverwriteFileValueIndent(v interface{}, filename string) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(filename, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+	return WriteBytes(b, f)
 }
 
 // EnsureDir creates directory if it doesnt exist


### PR DESCRIPTION
* fix issue where dpluger crashes when plugin title contains double-quote (`"`).
* plugin list now can contain optional kingdom, dpluger will use the kingdom value if it exist instead of default kingdom.
* fix behaviour where dpluger ignore multiple directives with same name but different `plugin_sid`.
