### PR TITLE
Fix: add option to import identifier block from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ test_directives
 dev_*
 
 .DS_STORE
+*.http

--- a/cmd/dpluger/run.go
+++ b/cmd/dpluger/run.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/defenxor/dsiem/internal/pkg/dpluger"
+	"github.com/defenxor/dsiem/internal/pkg/shared/fs"
+	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	runCmd.Flags().BoolP("skipTLSVerify", "s", false, "whether to skip ES server certificate verification (when using HTTPS)")
+	runCmd.Flags().BoolP("usePipeline", "p", false, "whether to generate plugin that is suitable for logstash pipeline to pipeline configuration")
+	runCmd.Flags().BoolP("validate", "v", true, "Check whether each referred ES field exists on the target index")
+	viper.BindPFlag("validate", runCmd.Flags().Lookup("validate"))
+	viper.BindPFlag("skipTLSVerify", runCmd.Flags().Lookup("skipTLSVerify"))
+	viper.BindPFlag("usePipeline", runCmd.Flags().Lookup("usePipeline"))
+
+	rootCmd.AddCommand(runCmd)
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Create Logstash plugin for Dsiem",
+	Long:  `Create Logstash plugin for Dsiem`,
+	Run: func(cmd *cobra.Command, args []string) {
+		config := viper.GetString("config")
+		validate := viper.GetBool("validate")
+		skipTLSVerify := viper.GetBool("skipTLSVerify")
+		usePipeline := viper.GetBool("usePipeline")
+
+		if skipTLSVerify {
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+
+		if !fs.FileExist(config) {
+			exit("Cannot read from config file", errors.New(config+" doesn't exist"))
+		}
+		if err := log.Setup(true); err != nil {
+			exit("Cannot setup logger", err)
+		}
+		plugin, err := dpluger.Parse(config)
+		if err != nil {
+			exit("Cannot parse config file", err)
+		}
+		if err := dpluger.CreatePlugin(plugin, config, progName, validate, usePipeline); err != nil {
+			exit("Error encountered while running config file", err)
+		}
+		fmt.Println("Logstash conf file created.")
+	},
+}

--- a/internal/pkg/dpluger/template.go
+++ b/internal/pkg/dpluger/template.go
@@ -26,6 +26,16 @@ var templHeader = `
 
 `
 
+var templWithIdentifierBlockContent = `
+filter {
+
+# 1st and 2nd step provided by file {{ .P.IdentifierBlockSource }}
+
+    {{ indent 2 .P.IdentifierBlockSourceContent }}
+
+}
+`
+
 var templNonPipeline = `
 
 filter {


### PR DESCRIPTION
update for `dpluger run` command:
- add option for importing identifier block from file. To do this, create a file containing identifier block, and specify the path to the file in `identifier_block_source` for the `dpluger run` config file. This way, the `dpluger run` will ignore `identifier_field`, `identifier_value`, and `identifier_filter` value, and use the value from the block file instead.