### PR TITLE
fix: add keyword field checking

### DIFF
--- a/internal/pkg/dpluger/dpluger.go
+++ b/internal/pkg/dpluger/dpluger.go
@@ -19,6 +19,7 @@ package dpluger
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,7 +80,7 @@ const (
 	ftES
 )
 
-var esVersion int
+// var esVersion int
 var collector esCollector
 
 // Parse read dpluger config from confFile and returns a Plugin
@@ -249,13 +250,17 @@ func createPluginNonCollect(plugin Plugin, confFile, creator, esFilter string, v
 	return nil
 }
 
+var (
+	ErrCollectOnNonSID = errors.New("only SID-type plugin support collect: keyword")
+)
+
 func createPluginCollect(plugin Plugin, confFile, creator, esFilter string, validate, usePipeline bool) (err error) {
 
 	// Taxonomy type plugin doesnt need to collect title since it is relying on
 	// category field (which doesnt have to be unique per title) instead of Plugin_SID
 	// that requires a unique SID for each title
 	if plugin.Type != "SID" {
-		return errors.New("Only SID-type plugin support collect: keyword")
+		return ErrCollectOnNonSID
 	}
 
 	// first get the refs
@@ -405,12 +410,34 @@ func setField(f *FieldMapping, field string, value string) {
 
 func collectPair(plugin Plugin, confFile, esFilter string, validate bool) (c tsvRef, err error) {
 	sidSource := strings.Replace(plugin.Fields.PluginSID, "es:", "", 1)
-	titleSource := strings.Replace(plugin.Fields.Title, "es:", "", 1) + ".keyword"
+
+	_, haskeyword, err := collector.FieldType(context.Background(), plugin.Index, plugin.Fields.Title)
+	if err != nil {
+		return tsvRef{}, err
+	}
+
+	var titleSource string
+	if haskeyword {
+		titleSource = strings.Replace(plugin.Fields.Title, "es:", "", 1) + ".keyword"
+	} else {
+		titleSource = strings.Replace(plugin.Fields.Title, "es:", "", 1)
+	}
+
 	shouldCollectCategory := false
 	categorySource := plugin.Fields.Category
+
 	if strings.Contains(plugin.Fields.Category, "es:") {
+		_, haskeyword, err = collector.FieldType(context.Background(), plugin.Index, plugin.Fields.Category)
+		if err != nil {
+			return tsvRef{}, err
+		}
+
 		shouldCollectCategory = true
-		categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1) + ".keyword"
+		if haskeyword {
+			categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1) + ".keyword"
+		} else {
+			categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1)
+		}
 	}
 
 	if validate {
@@ -439,6 +466,9 @@ func collectPair(plugin Plugin, confFile, esFilter string, validate bool) (c tsv
 			if err != nil {
 				return
 			}
+
+			// TODO: check the exist
+			_ = exist
 		}
 		fmt.Println("OK")
 	}
@@ -450,12 +480,34 @@ func collectPair(plugin Plugin, confFile, esFilter string, validate bool) (c tsv
 }
 
 func collectSID(plugin Plugin, confFile, esFilter string, validate bool) (c tsvRef, err error) {
-	sidSource := strings.Replace(plugin.Fields.PluginSID, "collect:", "", 1) + ".keyword"
+	_, haskeyword, err := collector.FieldType(context.Background(), plugin.Index, plugin.Fields.PluginSID)
+	if err != nil {
+		return tsvRef{}, err
+	}
+
+	var sidSource string
+
+	if haskeyword {
+		sidSource = strings.Replace(plugin.Fields.PluginSID, "collect:", "", 1) + ".keyword"
+	} else {
+		sidSource = strings.Replace(plugin.Fields.PluginSID, "collect:", "", 1)
+	}
+
 	shouldCollectCategory := false
 	categorySource := plugin.Fields.Category
+
 	if strings.Contains(plugin.Fields.Category, "es:") {
+		_, haskeyword, err := collector.FieldType(context.Background(), plugin.Index, plugin.Fields.PluginSID)
+		if err != nil {
+			return tsvRef{}, err
+		}
+
 		shouldCollectCategory = true
-		categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1) + ".keyword"
+		if haskeyword {
+			categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1) + ".keyword"
+		} else {
+			categorySource = strings.Replace(plugin.Fields.Category, "es:", "", 1)
+		}
 	}
 
 	if validate {
@@ -471,7 +523,7 @@ func collectSID(plugin Plugin, confFile, esFilter string, validate bool) (c tsvR
 		}
 		if shouldCollectCategory {
 			fmt.Print("Checking the existence of field ", categorySource, "... ")
-			exist, err = collector.IsESFieldExist(plugin.Index, categorySource)
+			_, err = collector.IsESFieldExist(plugin.Index, categorySource)
 			if err != nil {
 				return
 			}

--- a/internal/pkg/dpluger/es5client.go
+++ b/internal/pkg/dpluger/es5client.go
@@ -245,7 +245,15 @@ func (es *es5Client) FieldType(ctx context.Context, index string, field string) 
 		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
 	}
 
-	f, ok := mappings[field].(map[string]interface{})
+	doc, ok := mappings["_doc"].(map[string]interface{})
+	if !ok || mappings == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	f, ok := doc[field].(map[string]interface{})
+	if !ok || f == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
 	if !ok || f == nil {
 		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
 	}

--- a/internal/pkg/dpluger/es5client.go
+++ b/internal/pkg/dpluger/es5client.go
@@ -215,3 +215,62 @@ func (es *es5Client) IsESFieldExist(index string, field string) (exist bool, err
 	}
 	return
 }
+
+func (es *es5Client) FieldType(ctx context.Context, index string, field string) (string, bool, error) {
+	m, err := elastic5.NewGetFieldMappingService(es.client).
+		Field(field).
+		Index(index).
+		Type("_doc").
+		Do(ctx)
+
+	if err != nil {
+		return "", false, err
+	}
+
+	var indexSettings map[string]interface{}
+	var ok bool
+	for _, v := range m {
+		indexSettings, ok = v.(map[string]interface{})
+		if ok && indexSettings != nil {
+			break
+		}
+	}
+
+	if !ok {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	mappings, ok := indexSettings["mappings"].(map[string]interface{})
+	if !ok || mappings == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	f, ok := mappings[field].(map[string]interface{})
+	if !ok || f == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	mapping, ok := f["mapping"].(map[string]interface{})[field].(map[string]interface{})
+	if !ok || mapping == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	fieldType, ok := mapping["type"].(string)
+	if !ok {
+		return "", false, fmt.Errorf("invalid field type for '%s'", field)
+	}
+
+	var iskeyword bool
+	keyword, ok := mapping["fields"].(map[string]interface{})
+	if ok && keyword != nil {
+		kword, ok := keyword["keyword"].(map[string]interface{})
+		if ok && kword != nil {
+			ktype, ok := kword["type"].(string)
+			if ok && ktype == "keyword" {
+				iskeyword = true
+			}
+		}
+	}
+
+	return fieldType, iskeyword, nil
+}

--- a/internal/pkg/dpluger/es6client.go
+++ b/internal/pkg/dpluger/es6client.go
@@ -245,7 +245,12 @@ func (es *es6Client) FieldType(ctx context.Context, index string, field string) 
 		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
 	}
 
-	f, ok := mappings[field].(map[string]interface{})
+	doc, ok := mappings["_doc"].(map[string]interface{})
+	if !ok || mappings == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	f, ok := doc[field].(map[string]interface{})
 	if !ok || f == nil {
 		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
 	}

--- a/internal/pkg/dpluger/es6client.go
+++ b/internal/pkg/dpluger/es6client.go
@@ -215,3 +215,62 @@ func (es *es6Client) IsESFieldExist(index string, field string) (exist bool, err
 	}
 	return
 }
+
+func (es *es6Client) FieldType(ctx context.Context, index string, field string) (string, bool, error) {
+	m, err := elastic6.NewGetFieldMappingService(es.client).
+		Field(field).
+		Index(index).
+		Type("_doc").
+		Do(ctx)
+
+	if err != nil {
+		return "", false, err
+	}
+
+	var indexSettings map[string]interface{}
+	var ok bool
+	for _, v := range m {
+		indexSettings, ok = v.(map[string]interface{})
+		if ok && indexSettings != nil {
+			break
+		}
+	}
+
+	if !ok {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	mappings, ok := indexSettings["mappings"].(map[string]interface{})
+	if !ok || mappings == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	f, ok := mappings[field].(map[string]interface{})
+	if !ok || f == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	mapping, ok := f["mapping"].(map[string]interface{})[field].(map[string]interface{})
+	if !ok || mapping == nil {
+		return "", false, fmt.Errorf("no mappings found for field '%s'", field)
+	}
+
+	fieldType, ok := mapping["type"].(string)
+	if !ok {
+		return "", false, fmt.Errorf("invalid field type for '%s'", field)
+	}
+
+	var iskeyword bool
+	keyword, ok := mapping["fields"].(map[string]interface{})
+	if ok && keyword != nil {
+		kword, ok := keyword["keyword"].(map[string]interface{})
+		if ok && kword != nil {
+			ktype, ok := kword["type"].(string)
+			if ok && ktype == "keyword" {
+				iskeyword = true
+			}
+		}
+	}
+
+	return fieldType, iskeyword, nil
+}

--- a/internal/pkg/dpluger/esclient.go
+++ b/internal/pkg/dpluger/esclient.go
@@ -17,6 +17,7 @@
 package dpluger
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -32,6 +33,7 @@ type esCollector interface {
 	CollectPair(plugin Plugin, confFile, sidSource, esFilter, titleSource, categorySource string, shouldCollectCategory bool) (c tsvRef, err error)
 	ValidateIndex(index string) (err error)
 	IsESFieldExist(index string, field string) (exist bool, err error)
+	FieldType(ctx context.Context, index, field string) (fieldType string, hasKeyword bool, err error)
 }
 
 func newESCollector(esURL string) (collector esCollector, err error) {


### PR DESCRIPTION
* prevent panic on dpluger if field with `es:` annotation on elasticsearch doesn't have any .keyword field