### PR TITLE
fix: (dpluger) add aggregation key type checking

### DIFF
--- a/internal/pkg/dpluger/es5client.go
+++ b/internal/pkg/dpluger/es5client.go
@@ -94,7 +94,10 @@ func (es *es5Client) CollectPair(plugin Plugin, confFile, sidSource, esFilter, t
 		}
 		for _, lvl2Bucket := range subterm.Buckets {
 			sKey := lvl1Bucket.Key.(string)
-			nKey := int(lvl2Bucket.Key.(float64))
+			nKey, err := toInt(lvl2Bucket.Key)
+			if err != nil {
+				return c, fmt.Errorf("invalid sid aggregation key, %s", err.Error())
+			}
 			// fmt.Println("item1:", sKey, "item2:", nKey)
 			if shouldCollectCategory {
 				subSubTerm, found2 := lvl1Bucket.Terms("subSubTerm")

--- a/internal/pkg/dpluger/es6client.go
+++ b/internal/pkg/dpluger/es6client.go
@@ -95,7 +95,10 @@ func (es *es6Client) CollectPair(plugin Plugin, confFile, sidSource, esFilter, t
 		}
 		for _, lvl2Bucket := range subterm.Buckets {
 			sKey := lvl1Bucket.Key.(string)
-			nKey := int(lvl2Bucket.Key.(float64))
+			nKey, err := toInt(lvl2Bucket.Key)
+			if err != nil {
+				return c, fmt.Errorf("invalid sid aggregation key, %s", err.Error())
+			}
 			// fmt.Println("item1:", sKey, "item2:", nKey)
 			if shouldCollectCategory {
 				subSubTerm, found2 := lvl1Bucket.Terms("subSubTerm")

--- a/internal/pkg/dpluger/es7client.go
+++ b/internal/pkg/dpluger/es7client.go
@@ -136,7 +136,7 @@ func (es *es7Client) Collect(plugin Plugin, confFile, sidSource, esFilter, categ
 		for _, v := range coll {
 			s := strings.Split(v, "=")
 			if len(s) != 2 {
-				err = errors.New("Cannot split the ES filter term")
+				err = errors.New("cannot split the ES filter term")
 				return
 			}
 			query = query.Must(elastic7.NewTermQuery(s[0], s[1]))

--- a/internal/pkg/dpluger/es7client.go
+++ b/internal/pkg/dpluger/es7client.go
@@ -95,8 +95,11 @@ func (es *es7Client) CollectPair(plugin Plugin, confFile, sidSource, esFilter, t
 		}
 		for _, lvl2Bucket := range subterm.Buckets {
 			sKey := lvl1Bucket.Key.(string)
-			nKey := int(lvl2Bucket.Key.(float64))
-			// fmt.Println("item1:", sKey, "item2:", nKey)
+			nKey, err := toInt(lvl2Bucket.Key)
+			if err != nil {
+				return c, fmt.Errorf("invalid sid aggregation key, %s", err.Error())
+			}
+
 			if shouldCollectCategory {
 				subSubTerm, found2 := lvl1Bucket.Terms("subSubTerm")
 				if !found2 {

--- a/internal/pkg/dpluger/util.go
+++ b/internal/pkg/dpluger/util.go
@@ -1,6 +1,7 @@
 package dpluger
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -219,6 +220,10 @@ func ruleEqual(rule1, rule2 rule.DirectiveRule) []error {
 	return errors
 }
 
+var (
+	ErrIntValueExceedBoundary = errors.New("integer value exceeds maximum value boundary")
+)
+
 // toInt safely convert interface into int.
 func toInt(v interface{}) (int, error) {
 	if v == nil {
@@ -230,7 +235,7 @@ func toInt(v interface{}) (int, error) {
 		return t, nil
 	case float64:
 		if t > math.MaxInt {
-			return 0, fmt.Errorf("value is larger than %d", math.MaxInt)
+			return 0, ErrIntValueExceedBoundary
 		}
 
 		return int(t), nil
@@ -241,11 +246,11 @@ func toInt(v interface{}) (int, error) {
 		}
 
 		if n > math.MaxInt {
-			return 0, fmt.Errorf("value is larger than %d", math.MaxInt)
+			return 0, ErrIntValueExceedBoundary
 		}
 
 		return int(n), nil
 	}
 
-	return 0, fmt.Errorf("unknown value type, %T", v)
+	return 0, ErrIntValueExceedBoundary
 }

--- a/internal/pkg/dpluger/util.go
+++ b/internal/pkg/dpluger/util.go
@@ -234,22 +234,28 @@ func toInt(v interface{}) (int, error) {
 	case int:
 		return t, nil
 	case float64:
-		if t > math.MaxInt {
-			return 0, ErrIntValueExceedBoundary
+		if t > 0 && t < math.MaxInt32 {
+			return int(t), nil
 		}
 
-		return int(t), nil
+		return 0, ErrIntValueExceedBoundary
+	case int64:
+		if t > 0 && t < math.MaxInt32 {
+			return int(t), nil
+		}
+
+		return 0, ErrIntValueExceedBoundary
 	case string:
 		n, err := strconv.ParseInt(t, 10, 64)
 		if err != nil {
 			return 0, err
 		}
 
-		if n > math.MaxInt {
-			return 0, ErrIntValueExceedBoundary
+		if n > 0 && n < math.MaxInt32 {
+			return int(n), nil
 		}
 
-		return int(n), nil
+		return 0, ErrIntValueExceedBoundary
 	}
 
 	return 0, fmt.Errorf("invalid value type, %T", v)

--- a/internal/pkg/dpluger/util.go
+++ b/internal/pkg/dpluger/util.go
@@ -2,7 +2,9 @@ package dpluger
 
 import (
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/defenxor/dsiem/internal/pkg/dsiem/rule"
@@ -215,4 +217,35 @@ func ruleEqual(rule1, rule2 rule.DirectiveRule) []error {
 	}
 
 	return errors
+}
+
+// toInt safely convert interface into int.
+func toInt(v interface{}) (int, error) {
+	if v == nil {
+		return 0, nil
+	}
+
+	switch t := v.(type) {
+	case int:
+		return t, nil
+	case float64:
+		if t > math.MaxInt {
+			return 0, fmt.Errorf("value is larger than %d", math.MaxInt)
+		}
+
+		return int(t), nil
+	case string:
+		n, err := strconv.ParseInt(t, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		if n > math.MaxInt {
+			return 0, fmt.Errorf("value is larger than %d", math.MaxInt)
+		}
+
+		return int(n), nil
+	}
+
+	return 0, fmt.Errorf("unknown value type, %T", v)
 }

--- a/internal/pkg/dpluger/util.go
+++ b/internal/pkg/dpluger/util.go
@@ -252,5 +252,5 @@ func toInt(v interface{}) (int, error) {
 		return int(n), nil
 	}
 
-	return 0, ErrIntValueExceedBoundary
+	return 0, fmt.Errorf("invalid value type, %T", v)
 }


### PR DESCRIPTION
- add type checking for aggregation key conversion, this prevent panic when the resulted aggregation key isn't `float64`