### PR TITLE
Add backlog manager reload mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dev_*
 .DS_STORE
 *.http
 .dccache
+*.exe

--- a/cmd/dsiem/main.go
+++ b/cmd/dsiem/main.go
@@ -296,8 +296,13 @@ external message queue.`,
 			if err != nil {
 				exit("Cannot initialize alarm", err)
 			}
+
+			interruptChannel := make(chan os.Signal, 1)
+			signal.Notify(interruptChannel, os.Interrupt)
+
 			err = siem.InitBackLogManager(path.Join(logDir, aEventsLogs),
-				sendBpChan, holdDuration)
+				sendBpChan, interruptChannel, holdDuration)
+
 			if err != nil {
 				exit("Cannot initialize backlog manager", err)
 			}

--- a/internal/pkg/dsiem/rule/rule.go
+++ b/internal/pkg/dsiem/rule/rule.go
@@ -64,8 +64,8 @@ type DirectiveRule struct {
 // This is mutable, so its separated from DirectiveRule
 type StickyDiffData struct {
 	sync.RWMutex
-	SDiffString []string
-	SDiffInt    []int
+	SDiffString []string `json:"sticky_diff_strings"`
+	SDiffInt    []int    `json:"sticky_diff_ints"`
 }
 
 // CustomData combine all custom fields into a struct for easier use

--- a/internal/pkg/dsiem/siem/backlog_test.go
+++ b/internal/pkg/dsiem/siem/backlog_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/defenxor/dsiem/internal/pkg/dsiem/event"
 	"github.com/defenxor/dsiem/internal/pkg/shared/apm"
 	log "github.com/defenxor/dsiem/internal/pkg/shared/logger"
-	"github.com/jonhoo/drwmutex"
 )
 
 var (
@@ -118,7 +118,8 @@ func TestBackLog(t *testing.T) {
 	}
 	bLogs := backlogs{}
 	bLogs.bpCh = make(chan bool)
-	bLogs.DRWMutex = drwmutex.New()
+	// bLogs.DRWMutex = drwmutex.New()
+	bLogs.mut = sync.RWMutex{}
 	bLogs.bl = make(map[string]*backLog)
 	bLogs.bl[b.ID] = b
 	// bLogs.bl[b.ID].DRWMutex = drwmutex.New()

--- a/internal/pkg/dsiem/siem/backlog_test.go
+++ b/internal/pkg/dsiem/siem/backlog_test.go
@@ -59,7 +59,7 @@ func initAsset(t *testing.T) {
 	if assetInitialized {
 		return
 	}
-	err := asset.Init(path.Join(testDir, "internal", "pkg", "dsiem", "asset", "fixtures", "asset1"))
+	err := asset.Init(path.Join(testDirPath, "internal", "pkg", "dsiem", "asset", "fixtures", "asset1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestBackLog(t *testing.T) {
 	fmt.Println("Starting TestBackLog.")
 
 	setTestDir(t)
-	t.Logf("Using base dir %s", testDir)
+	t.Logf("Using base dir %s", testDirPath)
 
 	if !log.TestMode {
 		t.Logf("Enabling log test mode")
@@ -82,7 +82,7 @@ func TestBackLog(t *testing.T) {
 	tmpLog := path.Join(os.TempDir(), "siem_alarm_events.log")
 	fWriter.Init(tmpLog, 10)
 
-	fDir := path.Join(testDir, "internal", "pkg", "dsiem", "siem", "fixtures")
+	fDir := path.Join(testDirPath, "internal", "pkg", "dsiem", "siem", "fixtures")
 
 	// use directive that expires fast and has only 3 stages
 	dirs, _, err := LoadDirectivesFromFile(path.Join(fDir, "directive4"), directiveFileGlob, false)
@@ -120,8 +120,8 @@ func TestBackLog(t *testing.T) {
 	bLogs.bpCh = make(chan bool)
 	// bLogs.DRWMutex = drwmutex.New()
 	bLogs.mut = sync.RWMutex{}
-	bLogs.bl = make(map[string]*backLog)
-	bLogs.bl[b.ID] = b
+	bLogs.blogs = make(map[string]*backLog)
+	bLogs.blogs[b.ID] = b
 	// bLogs.bl[b.ID].DRWMutex = drwmutex.New()
 	b.bLogs = &bLogs
 

--- a/internal/pkg/dsiem/siem/backlogmgr.go
+++ b/internal/pkg/dsiem/siem/backlogmgr.go
@@ -276,6 +276,12 @@ mainLoop:
 			go func(k string) {
 				defer wg.Done()
 				// this first select is required, see #2 on https://go101.org/article/channel-closing.html
+				// Note: Detail
+				// It is required because there can exist a race condition when both chDone and
+				// incomingEvent channel receive data at the same time, which would prompt the
+				// Go runtime to randomly select the blogs.blogs[k].chData <-incomingEvent branch to run.
+				// This can lead to a running backlog go routine to eventually calling close(chDone)
+				// even tho the chDone channel is already closed.
 				select {
 				// exit early if done, this should be the case while backlog in waiting for deletion mode
 				case <-blogs.blogs[k].chDone:

--- a/internal/pkg/dsiem/siem/directive.go
+++ b/internal/pkg/dsiem/siem/directive.go
@@ -52,7 +52,7 @@ type Directive struct {
 	Kingdom              string                `json:"kingdom"`
 	Category             string                `json:"category"`
 	Rules                []rule.DirectiveRule  `json:"rules"`
-	StickyDiffs          []rule.StickyDiffData `json:"-"`
+	StickyDiffs          []rule.StickyDiffData `json:"sticky_differents"`
 }
 
 // Directives group directive together
@@ -84,9 +84,9 @@ func InitDirectives(confDir string, ch <-chan event.NormalizedEvent, minAlarmLif
 		blogs := backlogs{}
 		// blogs.DRWMutex = drwmutex.New()
 		blogs.mut = sync.RWMutex{}
-		blogs.id = i
+		blogs.Id = i
 		blogs.bpCh = make(chan bool)
-		blogs.bl = make(map[string]*backLog) // have to do it here before the append
+		blogs.blogs = make(map[string]*backLog) // have to do it here before the append
 		allBacklogsMu.Lock()
 		allBacklogs = append(allBacklogs, &blogs)
 		allBacklogsMu.Unlock()

--- a/internal/pkg/dsiem/siem/directive_test.go
+++ b/internal/pkg/dsiem/siem/directive_test.go
@@ -36,8 +36,8 @@ func TestInitDirective(t *testing.T) {
 
 	setTestDir(t)
 
-	t.Logf("Using base dir %s", testDir)
-	fDir := path.Join(testDir, "internal", "pkg", "dsiem", "siem", "fixtures")
+	t.Logf("Using base dir %s", testDirPath)
+	fDir := path.Join(testDirPath, "internal", "pkg", "dsiem", "siem", "fixtures")
 	evtChan := make(chan event.NormalizedEvent)
 	err := InitDirectives(path.Join(fDir, "directive2"), evtChan, 0, 1000, 0)
 
@@ -65,7 +65,7 @@ func TestInitDirective(t *testing.T) {
 	e.PluginID = 1001
 	e.RcvdTime = time.Now().UnixNano()
 
-	err = asset.Init(path.Join(testDir, "internal", "pkg", "dsiem", "asset", "fixtures", "asset1"))
+	err = asset.Init(path.Join(testDirPath, "internal", "pkg", "dsiem", "asset", "fixtures", "asset1"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/dsiem/siem/directive_test.go
+++ b/internal/pkg/dsiem/siem/directive_test.go
@@ -29,7 +29,7 @@ import (
 func TestInitDirective(t *testing.T) {
 
 	allBacklogsMu.Lock()
-	allBacklogs = []backlogs{}
+	allBacklogs = []*backlogs{}
 	allBacklogsMu.Unlock()
 
 	fmt.Println("Starting TestInitDirective.")


### PR DESCRIPTION
Save all backlogs on interrupt, and can reload on the next run.